### PR TITLE
reg expression fix all half symbol

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -16,7 +16,7 @@ bot.mention do |event|
     event.respond '生きてます。'
 end
 
-bot.message(contains: /^(?!http)(?!.*<@)(?!.*<#)(?!.*<:)(?!.*<a:)(?!.*<t:)[!-~]{20,}$/) do |event|
+bot.message(contains: /^(?!http)(?!.*<@)(?!.*<#)(?!.*<:)(?!.*<a:)(?!.*<t:)[ -/:-@\[-~]{20,}$/) do |event|
     event.respond 'ハッシュ値やアクセストークンの疑いがある文字列を検知しました。'
     api.add_member_role("Bot #{TOKEN}", SERVER_ID, event.user.id, ISOLATE_ROLE_ID)
     api.remove_member_role("Bot #{TOKEN}", SERVER_ID, event.user.id, DEPRIVATE_ROLE_ID)


### PR DESCRIPTION
PR送信のテストも兼ねています
記号は全て対象にするべきかもしんないと思いました