### PR TITLE
タイムゾーンを日本に固定

### DIFF
--- a/controller/bot_controller.rb
+++ b/controller/bot_controller.rb
@@ -58,7 +58,7 @@ class BotController
 
   def check_reminder
     reminder_list = @service.fetch_reminder_list
-    now = Time.now
+    now = TimeUtil.now
     reminder_list.each do |reminder|
       if not reminder.done and now >= reminder.time
         @service.remind(reminder)

--- a/spec/bot_controller_spec.rb
+++ b/spec/bot_controller_spec.rb
@@ -117,9 +117,9 @@ describe 'BotControllerのテスト' do
 
   context "リマインダのチェックが走ったとき" do
 
-    let(:reminder_to_send) { Reminder.new(1, Time.now, "test", "test", "test", false) }
-    let(:reminder_already_sent) { Reminder.new(1, Time.now, "test", "test", "test", true) }
-    let(:reminder_not_yet) { Reminder.new(1, Time.now+3600, "test", "test", "test", false) }
+    let(:reminder_to_send) { Reminder.new(1, TimeUtil.now, "test", "test", "test", false) }
+    let(:reminder_already_sent) { Reminder.new(1, TimeUtil.now, "test", "test", "test", true) }
+    let(:reminder_not_yet) { Reminder.new(1, TimeUtil.now+3600, "test", "test", "test", false) }
 
     before do
       allow(service).to receive(:fetch_reminder_list).and_return([])

--- a/util/time_util.rb
+++ b/util/time_util.rb
@@ -1,17 +1,21 @@
 require 'time'
 
 module TimeUtil
+  def now
+    return Time.now.localtime('+09:00')
+  end
+
   def parse_date_time(date_str, time_str)
-    return Time.strptime(date_str + ' ' + time_str + '+9:00', '%Y/%m/%d %H:%M%z')
+    return Time.strptime(date_str + ' ' + time_str + '+09:00', '%Y/%m/%d %H:%M%z')
   end
 
   def parse_min_time(time_str)
-    return Time.strptime(time_str + '+9:00', '%Y%m%d%H%M%z')
+    return Time.strptime(time_str + '+09:00', '%Y%m%d%H%M%z')
   end
 
   def format_min_time(time)
     return time.strftime('%Y%m%d%H%M')
   end
 
-  module_function :parse_date_time, :parse_min_time, :format_min_time
+  module_function :now, :parse_date_time, :parse_min_time, :format_min_time
 end


### PR DESCRIPTION
現在時刻取得時にタイムゾーンを指定していなかったことで、本番環境でリマインダが発火しない不具合を修正しました。
ローカル環境のタイムゾーン指定をUTCに変更してbotを起動し、リマインダが発火することを確認しています。