### PR TITLE
夜ふかししているFPSプレイヤーを叱る機能を追加

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -7,28 +7,30 @@ require 'json'
 require 'time'
 
 require './controller/bot_controller'
+require './controller/daily_task_controller'
 require './model/reminder'
 
 # 環境変数読み込み
 Dotenv.load
 TOKEN = ENV['TOKEN']
-CLIENT_ID = ENV['CLIENT_ID']
+CLIENT_ID = ENV['CLIENT_ID'].to_i
 
 bot = Discordrb::Commands::CommandBot.new token: TOKEN, client_id: CLIENT_ID, prefix: '!ae '
-controller = BotController.new
+bot_controller = BotController.new
+daily_task_controller = DailyTaskController.new(bot)
 
 # メンション時の反応
 bot.mention do |event|
-  controller.handle_mention(event)
+  bot_controller.handle_mention(event)
 end
 
 bot.command :remind do |event, *args|
-  controller.handle_command(event, args, :remind)
+  bot_controller.handle_command(event, args, :remind)
 end
 
 # ハッシュ検知時の反応
 bot.message(contains: /^(?!.*http)(?!.*<@)(?!.*<#)(?!.*<:)(?!.*<a:)(?!.*<t:)(?!^AA.+A$)[!-~]{19,}$/) do |event|
-  controller.handle_message(event, :hash)
+  bot_controller.handle_message(event, :hash)
 end
 
 # bot起動
@@ -36,7 +38,8 @@ bot.run(true)
 
 # リマインダ起動
 loop do
-  controller.check_reminder
+  bot_controller.check_reminder
+  daily_task_controller.check_daily_task
   sleep 30
 end
 

--- a/config/constants.rb
+++ b/config/constants.rb
@@ -64,7 +64,12 @@ module Constants
     ADD_REMINDER = '%sに「%s」とリマインドする。……覚えた。'
     DENY_TOO_LONG_REMINDER = '……長すぎる。覚えられない。'
     REMIND = '「%s」……あなたは覚えてる？'
-    DEBY_NOT_SETUP_REMINDER = '今は何も覚えられないわ……研究員に相談して。'
+    DENY_NOT_SETUP_REMINDER = '今は何も覚えられないわ……研究員に相談して。'
+
+    WARN_FPS_PLAYERS = [
+      '寝なさい。',
+      '寝ることくらい、赤子だってできるのに。'
+    ]
   end
 end
 

--- a/controller/daily_task_controller.rb
+++ b/controller/daily_task_controller.rb
@@ -1,0 +1,19 @@
+require './service/daily_task_service'
+
+class DailyTaskController
+
+  def initialize(bot)
+    @service = DailyTaskSerivice.new(bot)
+  end
+
+  def check_daily_task
+    now = TimeUtil.now
+    # 2時〜5時（4時台）まで5分おき
+    if now.hour >= 2 and now.hour <= 4 and now - @service.last_warned_time >= 300
+      fps_players = @service.get_fps_players
+      if not fps_players.empty?
+        @service.warn_fps_players(fps_players)
+      end
+    end
+  end
+end

--- a/service/daily_task_service.rb
+++ b/service/daily_task_service.rb
@@ -1,0 +1,27 @@
+require './config/constants'
+require './util/time_util'
+
+Dotenv.load
+FPS_CHANNEL_ID = ENV['FPS_CHANNEL_ID'].to_i
+WARN_FPS_PLAYERS_CHANNEL_ID = ENV['WARN_FPS_PLAYERS_CHANNEL_ID'].to_i
+
+class DailyTaskSerivice
+  def initialize(bot)
+    @bot = bot
+    @last_warned_time = Time.at(0)
+  end
+
+  attr_reader :last_warned_time
+
+  def get_fps_players
+    @bot.channel(FPS_CHANNEL_ID).users
+  end
+
+  def warn_fps_players(fps_players)
+    mentions = fps_players.map do |fps_player|
+      "<@!#{fps_player.id}>"
+    end
+    @bot.channel(WARN_FPS_PLAYERS_CHANNEL_ID).send_message(mentions.join(" ") + Constants::Speech::WARN_FPS_PLAYERS.sample)
+    @last_warned_time = TimeUtil.now
+  end
+end

--- a/spec/daily_task_controller_spec.rb
+++ b/spec/daily_task_controller_spec.rb
@@ -1,0 +1,119 @@
+require './controller/daily_task_controller'
+require './service/daily_task_service'
+
+describe 'DailyTaskControllerのテスト' do
+
+  let(:bot) {double(:bot)}
+  let(:service) { double(:service) }
+  let(:event) { double(:event) }
+
+  before do
+    allow(DailyTaskSerivice).to receive(:new).and_return(service)
+  end
+
+  context "日次タスクのチェックが走ったとき" do
+
+    let(:fps_player_1) { double(:fps_player_1) }
+    let(:fps_player_2) { double(:fps_player_2) }
+
+    before do
+      allow(service).to receive(:last_warned_time).and_return(Time.at(0))
+    end
+
+    context "2時になっていたら（2:00ちょうど）" do
+      before do
+        allow(TimeUtil).to receive(:now).and_return(TimeUtil.parse_min_time("202201260200"))
+      end
+      
+      context "VCに入っているメンバーがいれば" do
+        before do
+          allow(fps_player_1).to receive(:id).and_return(1)
+          allow(fps_player_2).to receive(:id).and_return(2)
+          allow(service).to receive(:get_fps_players).and_return([fps_player_1, fps_player_2])
+        end
+
+        it "叱る" do
+          controller = DailyTaskController.new(bot)
+          expect(service).to receive(:warn_fps_players).with([fps_player_1, fps_player_2])
+          controller.check_daily_task
+        end
+      end
+
+      context "VCに入っているメンバーがいなければ" do
+        before do
+          allow(service).to receive(:get_fps_players).and_return([])
+        end
+
+        it "何もしない" do
+          controller = DailyTaskController.new(bot)
+          expect(service).not_to receive(:warn_fps_players)
+          controller.check_daily_task
+        end
+      end
+    end
+
+    context "5時になっていなければ（4:59）" do
+      before do
+        allow(fps_player_1).to receive(:id).and_return(1)
+        allow(fps_player_2).to receive(:id).and_return(2)
+        allow(TimeUtil).to receive(:now).and_return(TimeUtil.parse_min_time("202201260459"))
+      end
+
+      context "VCに入っているメンバーがいれば" do
+        before do
+          allow(service).to receive(:get_fps_players).and_return([fps_player_1, fps_player_2])
+        end
+
+        it "叱る" do
+          controller = DailyTaskController.new(bot)
+          expect(service).to receive(:warn_fps_players).with([fps_player_1, fps_player_2])
+          controller.check_daily_task
+        end
+      end
+
+      context "5分以内に既に叱っていたら" do
+        before do
+          allow(service).to receive(:get_fps_players).and_return([fps_player_1, fps_player_2])
+          allow(service).to receive(:last_warned_time).and_return(TimeUtil.parse_min_time("202201260455"))
+        end
+
+        it "何もしない" do
+          controller = DailyTaskController.new(bot)
+          expect(service).not_to receive(:get_fps_players)
+          expect(service).not_to receive(:warn_fps_players)
+          controller.check_daily_task
+        end
+      end
+    end
+    
+    context "2時になってなければ（1:59）" do
+      before do
+        allow(TimeUtil).to receive(:now).and_return(TimeUtil.parse_min_time("202201260159"))
+        allow(fps_player_1).to receive(:id).and_return(1)
+        allow(fps_player_2).to receive(:id).and_return(2)
+      end
+
+      it "何もしない" do
+        controller = DailyTaskController.new(bot)
+        expect(service).not_to receive(:get_fps_players)
+        expect(service).not_to receive(:warn_fps_players)
+        controller.check_daily_task
+      end
+    end
+
+    context "5時になっていたら（4:59）" do
+      before do
+        allow(TimeUtil).to receive(:now).and_return(TimeUtil.parse_min_time("202201260500"))
+        allow(fps_player_1).to receive(:id).and_return(1)
+        allow(fps_player_2).to receive(:id).and_return(2)
+      end
+
+      it "何もしない" do
+        controller = DailyTaskController.new(bot)
+        expect(service).not_to receive(:get_fps_players)
+        expect(service).not_to receive(:warn_fps_players)
+        controller.check_daily_task
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 機能
## 前準備
環境変数`FPS_CHANNEL_ID`にFPSのボイスチャンネルのID、`WARN_FPS_PLAYERS_CHANNEL_ID`にお叱りを飛ばすテキストチャンネルのIDを設定しておきます。

## 動作
2時〜5時の間、FPSのボイスチャンネルにいるメンバーに対して5分おきにメンションを飛ばし寝かしつけようとします。